### PR TITLE
Fix orphaned tool calls in auto-compaction system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-llm"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-llm"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "A Tower-based framework for building LLM & agent workflows in Rust."
 license = "MIT"

--- a/examples/auto_compaction.rs
+++ b/examples/auto_compaction.rs
@@ -10,7 +10,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 use tower_llm::{
-    auto_compaction::{CompactionPolicy, CompactionPrompt, CompactionStrategy, ProactiveThreshold},
+    auto_compaction::{
+        CompactionPolicy, CompactionPrompt, CompactionStrategy, OrphanedToolCallStrategy,
+        ProactiveThreshold,
+    },
     Agent, CompositePolicy, Service, ServiceExt,
 };
 
@@ -63,6 +66,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         ),
 
         max_compaction_attempts: 2,
+
+        // Handle orphaned tool calls (tool calls without responses) by dropping and re-appending
+        orphaned_tool_call_strategy: OrphanedToolCallStrategy::DropAndReappend,
     };
 
     // Build agent with auto-compaction


### PR DESCRIPTION


### Problem
The auto-compaction system would fail when attempting to compact conversations that ended with an assistant message containing tool calls but no corresponding tool response messages. This resulted in the error:

```
An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'
```

This is a common scenario when compaction is triggered mid-conversation, before tool calls have been executed.

### Solution
Added configurable handling for orphaned tool calls through a new `OrphanedToolCallStrategy` enum with four strategies:

- **`DropAndReappend`** (default): Temporarily removes orphaned tool calls before compaction, then re-appends them after the summary. This preserves the tool call intent while ensuring valid conversation structure.
- **`ExcludeFromCompaction`**: Adjusts the compaction range to exclude messages with orphaned tool calls.
- **`AddPlaceholderResponses`**: Adds synthetic tool response messages with placeholder content to maintain conversation validity.
- **`FailOnOrphaned`**: Fails compaction if orphaned tool calls are detected (previous behavior).

### Implementation Details
- Added detection logic to identify orphaned tool calls (assistant messages with tool calls but no following tool responses)
- Integrated handling into the `compact_messages` method with minimal changes to existing flow
- Maintains backward compatibility with sensible default behavior
- Follows TDD with comprehensive test coverage

### Testing
- Added tests for orphaned tool call detection
- Added tests for the drop-and-reappend strategy
- All existing tests continue to pass
- No clippy warnings

### Usage
```rust
let compaction_policy = CompactionPolicy {
    // ... other settings ...
    
    // Choose how to handle orphaned tool calls (default: DropAndReappend)
    orphaned_tool_call_strategy: OrphanedToolCallStrategy::DropAndReappend,
};
```

### Impact
- Fixes a critical bug that prevented compaction in common scenarios
- No breaking changes to existing API
- Default behavior automatically handles the issue
- Provides flexibility for different use cases through configurable strategies

This fix ensures that auto-compaction works reliably even when conversations are in progress, making the system more robust for production use.