### PR TITLE
Add async message transformation to handoff system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-llm"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-llm"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "A Tower-based framework for building LLM & agent workflows in Rust."
 license = "MIT"

--- a/examples/handoff_compaction.rs
+++ b/examples/handoff_compaction.rs
@@ -1,0 +1,192 @@
+//! Example demonstrating automatic conversation compaction during agent handoffs.
+//!
+//! This example shows how to use the CompactingHandoffPolicy to automatically
+//! compact conversation history when transferring control between agents.
+//! This helps manage context length and improves performance with long conversations.
+
+use async_openai::{config::OpenAIConfig, Client};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tower_llm::{
+    auto_compaction::{
+        CompactionPolicy, CompactionStrategy, OrphanedToolCallStrategy, ProactiveThreshold,
+    },
+    groups::{CompactingHandoffPolicy, HandoffCoordinator, MultiExplicitHandoffPolicy},
+    Agent, CompositePolicy, Service, ServiceExt,
+};
+
+/// Simple picker that always starts with the research agent
+#[derive(Clone)]
+struct ResearchFirstPicker;
+
+impl tower::Service<tower_llm::groups::PickRequest> for ResearchFirstPicker {
+    type Response = String;
+    type Error = tower::BoxError;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: tower_llm::groups::PickRequest) -> Self::Future {
+        Box::pin(async move { Ok("research".to_string()) })
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Initialize tracing for visibility
+    tracing_subscriber::fmt::init();
+
+    println!("=== Handoff with Compaction Example ===\n");
+    println!("This example demonstrates automatic conversation compaction during handoffs.");
+    println!("Watch as long conversations are automatically summarized when agents hand off.\n");
+
+    let client = Arc::new(Client::<OpenAIConfig>::new());
+
+    // Create research agent - gathers information
+    let research_agent = Agent::builder(client.clone())
+        .model("gpt-4o-mini")
+        .temperature(0.7)
+        .policy(CompositePolicy::new(vec![
+            tower_llm::policies::until_no_tool_calls(),
+            tower_llm::policies::max_steps(3),
+        ]))
+        .build();
+
+    // Create analysis agent - processes gathered information
+    let analysis_agent = Agent::builder(client.clone())
+        .model("gpt-4o-mini")
+        .temperature(0.3)
+        .policy(CompositePolicy::new(vec![
+            tower_llm::policies::until_no_tool_calls(),
+            tower_llm::policies::max_steps(3),
+        ]))
+        .build();
+
+    // Create report agent - generates final output
+    let report_agent = Agent::builder(client.clone())
+        .model("gpt-4o")
+        .temperature(0.5)
+        .policy(CompositePolicy::new(vec![
+            tower_llm::policies::until_no_tool_calls(),
+            tower_llm::policies::max_steps(2),
+        ]))
+        .build();
+
+    // Build the group with agents
+    let agents = HashMap::from([
+        ("research".to_string(), research_agent),
+        ("analysis".to_string(), analysis_agent),
+        ("report".to_string(), report_agent),
+    ]);
+
+    // Create handoff policy with explicit handoff tools
+    let mut handoffs = HashMap::new();
+    handoffs.insert("handoff_to_analysis".to_string(), "analysis".to_string());
+    handoffs.insert("handoff_to_report".to_string(), "report".to_string());
+    handoffs.insert("handoff_to_research".to_string(), "research".to_string());
+
+    let base_handoff_policy = MultiExplicitHandoffPolicy::new(handoffs);
+
+    // Configure compaction policy
+    let compaction_policy = CompactionPolicy {
+        // Use smaller model for compaction to save costs
+        compaction_model: "gpt-4o-mini".to_string(),
+
+        // Very low threshold to trigger compaction for demo purposes
+        // In production, you'd use a higher threshold like 8000-16000
+        proactive_threshold: Some(ProactiveThreshold {
+            token_threshold: 100, // Artificially low for demo
+            percentage_threshold: None,
+        }),
+
+        // Keep system message and last 2 messages, compact the middle
+        compaction_strategy: CompactionStrategy::PreserveSystemAndRecent { recent_count: 2 },
+
+        // Custom prompt for research compaction
+        compaction_prompt: tower_llm::auto_compaction::CompactionPrompt::Custom(
+            "Summarize the research and analysis so far, preserving all key findings, \
+             data points, and conclusions. Format as a brief but comprehensive summary."
+                .to_string(),
+        ),
+
+        max_compaction_attempts: 2,
+        orphaned_tool_call_strategy: OrphanedToolCallStrategy::DropAndReappend,
+    };
+
+    // Create provider for compaction
+    let provider = Arc::new(tokio::sync::Mutex::new(
+        tower_llm::provider::OpenAIProvider::new(client.clone()),
+    ));
+
+    // Wrap the handoff policy with compaction
+    let compacting_policy =
+        CompactingHandoffPolicy::new(base_handoff_policy, compaction_policy, provider);
+
+    // Create the handoff coordinator
+    let mut coordinator = HandoffCoordinator::new(agents, ResearchFirstPicker, compacting_policy);
+
+    // Create a research-heavy request that will build up context
+    let request = tower_llm::simple_chat_request(
+        "You are a helpful research and analysis system. Work through the task step by step.",
+        "Research the history and impact of the Tower pattern in software architecture. \
+         Start by gathering information about its origins, then analyze its benefits and drawbacks, \
+         and finally prepare a comprehensive report. \
+         \
+         For the research phase, provide detailed findings about: \
+         1. The origins and evolution of the Tower pattern \
+         2. Key implementations and frameworks \
+         3. Comparison with other architectural patterns \
+         4. Real-world use cases and success stories \
+         \
+         Make sure to gather extensive information before handing off to analysis. \
+         After research is complete, use handoff_to_analysis to proceed. \
+         After analysis, use handoff_to_report for the final output.",
+    );
+
+    println!("Starting multi-agent workflow with automatic compaction on handoff...\n");
+    println!("═══════════════════════════════════════════════════════════════\n");
+
+    // Execute the coordinator
+    let result = ServiceExt::ready(&mut coordinator)
+        .await?
+        .call(request)
+        .await?;
+
+    println!("\n═══════════════════════════════════════════════════════════════\n");
+    println!("Workflow complete!");
+    println!("Total messages: {}", result.messages.len());
+    println!("Total steps: {}", result.steps);
+    println!("Stop reason: {:?}", result.stop);
+
+    // Display the final message
+    if let Some(async_openai::types::ChatCompletionRequestMessage::Assistant(asst)) = result.messages.last() {
+        if let Some(content) = &asst.content {
+            println!("\n=== Final Output ===");
+            match content {
+                async_openai::types::ChatCompletionRequestAssistantMessageContent::Text(t) => {
+                    println!("{}", t);
+                }
+                _ => println!("(Non-text content)"),
+            }
+        }
+    }
+
+    println!("\n=== Key Features Demonstrated ===");
+    println!("✓ Multi-agent coordination with explicit handoffs");
+    println!("✓ Automatic conversation compaction during handoffs");
+    println!("✓ Context length management across agent boundaries");
+    println!("✓ Preservation of orphaned tool calls during compaction");
+    println!("✓ Graceful fallback if compaction fails");
+
+    println!("\nNote: With the low token threshold (100), compaction likely triggered");
+    println!("during handoffs. Check the logs to see compaction in action!");
+
+    Ok(())
+}

--- a/examples/handoff_compaction.rs
+++ b/examples/handoff_compaction.rs
@@ -166,7 +166,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Stop reason: {:?}", result.stop);
 
     // Display the final message
-    if let Some(async_openai::types::ChatCompletionRequestMessage::Assistant(asst)) = result.messages.last() {
+    if let Some(async_openai::types::ChatCompletionRequestMessage::Assistant(asst)) =
+        result.messages.last()
+    {
         if let Some(content) = &asst.content {
             println!("\n=== Final Output ===");
             match content {

--- a/src/auto_compaction/mod.rs
+++ b/src/auto_compaction/mod.rs
@@ -280,10 +280,10 @@ impl<P, C> AutoCompactionLayer<P, C> {
 
 /// Service wrapper that performs auto-compaction
 pub struct AutoCompaction<S, P, C> {
-    inner: Arc<tokio::sync::Mutex<S>>,
-    policy: CompactionPolicy,
-    provider: Arc<tokio::sync::Mutex<P>>,
-    token_counter: Arc<C>,
+    pub(crate) inner: Arc<tokio::sync::Mutex<S>>,
+    pub(crate) policy: CompactionPolicy,
+    pub(crate) provider: Arc<tokio::sync::Mutex<P>>,
+    pub(crate) token_counter: Arc<C>,
 }
 
 impl<S, P, C> Layer<S> for AutoCompactionLayer<P, C>
@@ -364,7 +364,7 @@ where
     }
 
     /// Compact messages based on the configured strategy
-    async fn compact_messages(
+    pub(crate) async fn compact_messages(
         &self,
         messages: Vec<ChatCompletionRequestMessage>,
     ) -> Result<Vec<ChatCompletionRequestMessage>, BoxError> {


### PR DESCRIPTION
### Problem
The handoff system lacked the ability to transform messages when transferring control between agents. This limitation prevented important operations like:
- Managing context length during long multi-agent conversations
- Applying privacy filters when crossing trust boundaries
- Enriching context with agent-specific information
- Adapting message formats for different agent requirements

### Solution
Extended the `HandoffPolicy` trait with an optional `transform_on_handoff` method that enables async message transformation during handoffs. This provides a clean integration point for various transformation needs while maintaining backward compatibility.

### Implementation Details

#### Core Changes
- **Extended `HandoffPolicy` trait**: Added `transform_on_handoff` method with default no-op implementation
- **Updated `HandoffCoordinator`**: Applies transformations after handoff confirmation but before passing messages to the next agent
- **Graceful error handling**: Falls back to original messages if transformation fails

#### Built-in Transformations
- **`CompactingHandoffPolicy`**: A wrapper that adds automatic conversation compaction during handoffs
  - Reuses the auto-compaction logic from PR #1 (orphaned tool call handling)
  - Configurable compaction strategies and models
  - Chains transformations (inner policy → compaction)

### API Changes
```rust
// New method in HandoffPolicy trait (with default implementation)
fn transform_on_handoff(
    &self,
    messages: Vec<ChatCompletionRequestMessage>,
    from_agent: &str,
    to_agent: &str,
    handoff: &HandoffRequest,
) -> Pin<Box<dyn Future<Output = Result<Vec<ChatCompletionRequestMessage>, BoxError>> + Send>> {
    Box::pin(async move { Ok(messages) })  // Default: no transformation
}
```

### Usage Example
```rust
// Wrap any handoff policy with automatic compaction
let compaction_policy = CompactionPolicy {
    compaction_model: "gpt-4o-mini".to_string(),
    compaction_strategy: CompactionStrategy::PreserveSystemAndRecent { recent_count: 5 },
    orphaned_tool_call_strategy: OrphanedToolCallStrategy::DropAndReappend,
    ..Default::default()
};

let compacting_policy = CompactingHandoffPolicy::new(
    base_handoff_policy,
    compaction_policy,
    provider,
);

let coordinator = HandoffCoordinator::new(agents, picker, compacting_policy);
```

### Testing
- Added async test for default transformation behavior
- Created comprehensive example (`handoff_compaction.rs`) demonstrating the feature
- All 90 existing tests continue to pass
- No compilation warnings

### Documentation
- Updated `HANDOFF_GUIDE.md` with:
  - New trait method documentation
  - Dedicated "Message Transformation" section
  - Built-in and custom transformation examples
  - Use cases and transformation pipeline explanation
- Added inline documentation for all new types and methods

### Impact
- **No breaking changes**: Default implementation ensures backward compatibility
- **Extensible design**: Easy to add custom transformations for specific needs
- **Performance**: Transformations only run during handoffs, minimal overhead
- **Synergy with PR #1**: Leverages orphaned tool call handling for safe compaction

### Use Cases Enabled
1. **Context Management**: Automatically manage token limits in multi-agent workflows
2. **Privacy Compliance**: Redact sensitive data when agents cross security boundaries
3. **Multi-lingual Support**: Translate messages between agents operating in different languages
4. **Dynamic Enrichment**: Add relevant context from external systems during handoffs
5. **Agent Specialization**: Adapt message formats for agent-specific requirements

This enhancement makes the handoff system significantly more powerful and flexible while maintaining the clean, composable design philosophy of tower-llm.