### PR TITLE
Enhanced orphaned tool call handling for auto-compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-llm"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-llm"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 description = "A Tower-based framework for building LLM & agent workflows in Rust."
 license = "MIT"

--- a/examples/handoff_compaction.rs
+++ b/examples/handoff_compaction.rs
@@ -166,7 +166,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("Stop reason: {:?}", result.stop);
 
     // Display the final message
-    if let Some(async_openai::types::ChatCompletionRequestMessage::Assistant(asst)) = result.messages.last() {
+    if let Some(async_openai::types::ChatCompletionRequestMessage::Assistant(asst)) =
+        result.messages.last()
+    {
         if let Some(content) = &asst.content {
             println!("\n=== Final Output ===");
             match content {


### PR DESCRIPTION
### Problem
Auto-compaction was failing in production with the error:
```
An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. 
The following tool_call_ids did not have response messages: call_KsQuCF52hggtzsO4qxntLhJB (param: messages.[451].role)
```

The original implementation only handled orphaned tool calls at the **end** of conversations. However, in real-world scenarios with long conversations (400+ messages), orphaned tool calls can occur **anywhere** - particularly in the middle when conversations are interrupted or when agents move on before tool execution completes.

### Solution
Completely rewrote the orphaned tool call detection and handling to be comprehensive:

1. **Full conversation scanning**: Detects ALL orphaned tool calls throughout the entire conversation, not just at the end
2. **Proper ID matching**: Validates each tool call ID against its specific response
3. **Multiple orphan handling**: Can extract and re-append multiple orphaned messages while preserving order
4. **Conversation boundary awareness**: Stops searching for responses when hitting the next assistant message

### Implementation Details

#### Core Changes
- `find_orphaned_tool_calls()`: Returns indices of ALL messages containing orphaned tool calls
- `extract_all_orphaned_tool_calls()`: Removes and preserves multiple orphaned messages with their original indices
- Enhanced strategies now handle multiple orphaned calls:
  - **DropAndReappend**: Removes all orphaned messages, performs compaction, re-appends in order
  - **AddPlaceholderResponses**: Adds placeholders for all orphaned calls at correct positions
  - **ExcludeFromCompaction**: Keeps all messages but excludes orphaned ones from compaction range
  - **FailOnOrphaned**: Reports accurate count of orphaned messages

#### Key Improvements
- Handles partial orphaning (assistant message with multiple tool calls where only some have responses)
- Preserves conversation flow by maintaining relative order when re-appending
- More informative logging with counts of orphaned messages

### Testing
Added comprehensive test coverage with 14 tests including:
- ✅ Multiple orphaned tool calls in middle of conversation (production scenario)
- ✅ Mixed valid and orphaned tool calls
- ✅ Partial orphaning (multiple tool calls, only some with responses)
- ✅ Original end-of-conversation orphaned calls
- ✅ All existing compaction tests continue to pass

### Impact
- **Fixes critical production bug**: Handles orphaned tool calls at any position (like index 451)
- **No breaking changes**: Enhanced implementation maintains API compatibility
- **Better error messages**: Includes count of orphaned messages in error reporting
- **Production-ready**: Thoroughly tested with real-world scenarios

### Example Scenario Fixed
```rust
// Before: Would fail with orphaned tool call at index 451
// After: Successfully handles by:
// 1. Detecting orphaned call at index 451
// 2. Temporarily removing it
// 3. Compacting the valid conversation
// 4. Re-appending the orphaned call after compaction
```

This fix ensures auto-compaction works reliably even with complex, long-running conversations that may have multiple interrupted tool calls at various positions throughout the message history.