### PR TITLE
Agent-owned instructions (system) with streaming parity + docs and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,7 @@ checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-llm"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "async-openai",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tower-llm"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 description = "A Tower-based framework for building LLM & agent workflows in Rust."
 license = "MIT"

--- a/HANDOFF_GUIDE.md
+++ b/HANDOFF_GUIDE.md
@@ -288,6 +288,29 @@ let observable_coordinator = tower_llm::observability::TracingLayer::new()
 3. **Prevent loops**: Include maximum handoff limits
 4. **Clear semantics**: Tool names should be self-explanatory
 
+### Agent Instructions (System Prompt)
+
+- Prefer setting per-agent instructions on the agent itself via `AgentBuilder::instructions(...)`.
+- At runtime, each agent injects its instructions as the first `system` message for its steps.
+- Handoff policies and the coordinator should not mutate `system` messages; keep that concern at the agent boundary.
+- Example:
+
+```rust
+use std::sync::Arc;
+use async_openai::{config::OpenAIConfig, Client};
+use tower_llm::{Agent, run_user};
+
+let client = Arc::new(Client::<OpenAIConfig>::new());
+let triage = Agent::builder(client.clone())
+    .model("gpt-4o")
+    .instructions("You are TRIAGE. Ask clarifying questions and route appropriately.")
+    .build();
+let specialist = Agent::builder(client.clone())
+    .model("gpt-4o")
+    .instructions("You are SPECIALIST. Provide precise, technical answers.")
+    .build();
+```
+
 ### Error Handling
 
 1. **Validate handoffs**: Check target agents exist

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,10 +86,9 @@ mod core;
 // Re-export core types
 pub use core::{
     policies, run, run_user, simple_chat_request, simple_user_request, tool_typed, Agent,
-    AgentBuilder, AgentLoop, AgentLoopLayer,
-    AgentPolicy, AgentRun, AgentStopReason, AgentSvc, CompositePolicy, LoopState, Policy, PolicyFn,
-    Step, StepAux, StepLayer, StepOutcome, ToolDef, ToolInvocation, ToolOutput, ToolRouter,
-    ToolSvc,
+    AgentBuilder, AgentLoop, AgentLoopLayer, AgentPolicy, AgentRun, AgentStopReason, AgentSvc,
+    CompositePolicy, LoopState, Policy, PolicyFn, Step, StepAux, StepLayer, StepOutcome, ToolDef,
+    ToolInvocation, ToolOutput, ToolRouter, ToolSvc,
 };
 
 // Re-export join policy for tool execution configuration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! Set your OpenAI API key in the `OPENAI_API_KEY` environment variable.
 //!
 //! ```rust,no_run
-//! use tower_llm::{Agent, tool_typed, policies, CompositePolicy};
+//! use tower_llm::{Agent, tool_typed, policies, CompositePolicy, run_user};
 //! use async_openai::{config::OpenAIConfig, Client};
 //! use schemars::JsonSchema;
 //! use serde::Deserialize;
@@ -42,20 +42,18 @@
 //!     },
 //! );
 //!
-//! // Build an agent
+//! // Build an agent with per-agent instructions
 //! let agent = Agent::builder(client)
-//!     .model("gpt-4")
+//!     .model("gpt-4o")
+//!     .instructions("You are a helpful math assistant")
 //!     .tool(calculator)
 //!     .policy(CompositePolicy::new(vec![policies::until_no_tool_calls()]))
 //!     .build();
 //!
 //! // Use the agent with Tower's Service trait
 //! let mut agent = agent;
-//! let request = tower_llm::simple_chat_request(
-//!     "You are a helpful math assistant",
-//!     "What is 2 + 2?"
-//! );
-//! let response = agent.ready().await?.call(request).await?;
+//! // Send only a user message; the agent injects its instructions as a system message
+//! let response = run_user(&mut agent, "What is 2 + 2?").await?;
 //!
 //! println!("Agent: {:?}", response);
 //! # Ok(())
@@ -87,7 +85,8 @@ mod core;
 
 // Re-export core types
 pub use core::{
-    policies, run, simple_chat_request, tool_typed, Agent, AgentBuilder, AgentLoop, AgentLoopLayer,
+    policies, run, run_user, simple_chat_request, simple_user_request, tool_typed, Agent,
+    AgentBuilder, AgentLoop, AgentLoopLayer,
     AgentPolicy, AgentRun, AgentStopReason, AgentSvc, CompositePolicy, LoopState, Policy, PolicyFn,
     Step, StepAux, StepLayer, StepOutcome, ToolDef, ToolInvocation, ToolOutput, ToolRouter,
     ToolSvc,


### PR DESCRIPTION
Summary
- Adds per-agent “instructions” (system prompt) configured on AgentBuilder.
- Normalizes system injection: the agent ensures exactly one system message at index 0 per step.
- Parity for streaming and non-streaming paths.
- New helpers: run_user(...) and simple_user_request(...).
- Updates README, lib.rs doctest, and HANDOFF_GUIDE.
- Adds unit tests for handoffs, sessions, auto-compaction, and streaming.
- Clippy/tests green across all targets.

Motivation
- The system message is semantically the agent’s responsibility. Making it agent-owned simplifies handoffs and agent-level configuration, and avoids hidden mutations in coordinators or policies.

What changed
- Core
  - AgentBuilder::instructions(text) -> Self to set agent-level instructions.
  - Step/StepLayer: injects instructions on each call and normalizes the system message to the front (replace-or-prepend with dedup).
  - New helpers: run_user(&mut AgentSvc, user: &str) and simple_user_request(&str).
- Streaming
  - StepStreamService::instructions(text) -> Self and the same normalization logic.
- Groups/Handoffs
  - No functional change; coordinator/policies do not mutate system messages. New test verifies per-agent instructions across handoffs.
- Sessions/Auto-compaction/Recording/Approvals/Resilience/Budgets/Tap
  - No changes; behavior remains consistent and tested against the new injection semantics.
- Docs
  - README: architecture story expanded; new “Agent-level instructions (system)” section.
  - lib.rs: Getting Started uses .instructions(...) + run_user(...); re-exports run_user/simple_user_request.
  - HANDOFF_GUIDE.md: best-practice note for per-agent instructions.

API and migration
- Preferred:
  - Set `.instructions("...")` on each agent.
  - Use `run_user(agent, "user msg")` and `simple_user_request("user msg")`.
- Compatibility:
  - Existing `run(system, user)` and `simple_chat_request(system, user)` remain for now. Plan to deprecate in a follow-up.

Usage example
- Configure an agent with instructions and send only user messages:
```rust
let mut agent = Agent::builder(client)
  .model("gpt-4o")
  .instructions("You are helpful.")
  .tool(echo)
  .policy(CompositePolicy::new(vec![policies::max_steps(1)]))
  .build();

let run = tower_llm::run_user(&mut agent, "Say hi").await?;
```

Tests
- Core: injection/normalization; sessions preserve system at front; auto-compaction preserves system.
- Streaming: request passed to provider includes normalized system.
- Groups: handoff across agents with different instructions; each provider sees its agent’s system at index 0.
- All tests pass.

Quality gates
- cargo test: all passing across lib/examples/integration.
- cargo clippy --all-targets --all-features -- -D warnings: clean.

Notes and risks
- If an agent has instructions, any existing system message in the request is replaced by the agent’s instructions and normalized to the front. If instructions are not set, requests are forwarded unchanged.
- Coordinators/policies do not touch system messages, keeping responsibility localized to the agent.

Future work (optional follow-ups)
- Deprecate old helpers and update all examples to the new helpers.
- Broader README example refresh to consistently use `.instructions(...)` + `run_user(...)`.